### PR TITLE
Prevent taking plant clones

### DIFF
--- a/LootProtect.cs
+++ b/LootProtect.cs
@@ -878,6 +878,16 @@ namespace Oxide.Plugins
 
             return true;
         }
+		
+		private object CanTakeCutting(BasePlayer player, GrowableEntity entity)
+		{
+			if (player == null || entity == null) return null;
+			DoLog($"Player {player.displayName}:{player.UserIDString} taking a clone of {entity.ShortPrefabName}:{entity.OwnerID}");
+			if ((player.IsAdmin || permission.UserHasPermission(player.UserIDString, permLootProtAdmin)) && configData.Options.AdminBypass) return null;
+			if (CanAccess(entity.ShortPrefabName, player.userID, entity.OwnerID)) return null;
+
+			return true;
+		}
 
         private object OnCupboardAuthorize(BuildingPrivlidge privilege, BasePlayer player)
         {


### PR DESCRIPTION
With `OnGrowableGather` players that don't have access to the plant aren't allowed to harvest it, however, they can still take a clone of that plant resulting in plant theft. This PR adds the `CanTakeCutting` hook that would stop unauthorized players to take a clone of the plant. Since it's the same entity, it shouldn't need any config updates. 

Please consider reviewing this and adding it to the plugin, it would be really helpful, thanks!